### PR TITLE
fix: [ERP-3274] colour contrast used for new feature announcement

### DIFF
--- a/frontend/components/newFeature/newFeature.tsx
+++ b/frontend/components/newFeature/newFeature.tsx
@@ -13,12 +13,12 @@ export const NewFeature: FunctionComponent<
     <HStack
       pos={"relative"}
       w={"full"}
-      borderColor={"purple.200"}
+      borderColor={"purple.300"}
       borderWidth={2}
       p={2}
     >
       <Text
-        color={"purple.700"}
+        color={{ base: "purple.700", _dark: "purple.300" }}
         position={"absolute"}
         top={-3}
         bg={"bg"}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cea03d39-a70b-4dac-8b0b-f6fbdf1d3499)
![image](https://github.com/user-attachments/assets/a6c74b0b-4271-4c83-91a3-56e3dd200d03)
