### PR TITLE
[ERP-4908] Add default page title to fix login redirect tab title

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,5 +1,6 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
+import Head from "next/head";
 import { MonitoringProvider } from "../context/monitoring-context";
 import { Amplify } from "aws-amplify";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -76,6 +77,9 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
     ));
   return (
     <QueryClientProvider client={queryClient}>
+      <Head>
+        <title>QUT Transcribe</title>
+      </Head>
       <Provider>
         <AnalyticsProvider>
           <MonitoringProvider>


### PR DESCRIPTION
Adds a default `<title>` (QUT Transcribe) so the browser tab no longer shows the raw redirect URL (including the OAuth token fragment) after login.