### PR TITLE
[ERP-4928] Test feedback tweaks (translation UX, filenames, auth, links)

### DIFF
--- a/frontend/client/fetchers.ts
+++ b/frontend/client/fetchers.ts
@@ -66,12 +66,14 @@ export const getHeaders = async () =>
         "Content-Type": "application/json",
       } as HeadersInit;
     })
-    .catch(() => {
+    .catch((error) => {
       // A missing token here is usually a transient failed token refresh (a
       // network blip during background polling). Return no headers so the
       // caller skips this request and retries on its next poll, rather than
       // forcing a logout. A genuine session loss is surfaced as a `signedOut`
-      // auth event and handled in the auth context.
+      // auth event and handled in the auth context. Log the cause so repeated
+      // skips (e.g. a persistent auth problem) remain diagnosable.
+      console.debug("Skipping request: auth token unavailable", error);
       return undefined;
     });
 

--- a/frontend/client/fetchers.ts
+++ b/frontend/client/fetchers.ts
@@ -1,4 +1,4 @@
-import { fetchAuthSession, signOut } from "aws-amplify/auth";
+import { fetchAuthSession } from "aws-amplify/auth";
 
 export interface FetcherProps {
   apiUrl: string;
@@ -66,8 +66,13 @@ export const getHeaders = async () =>
         "Content-Type": "application/json",
       } as HeadersInit;
     })
-    .catch(async () => {
-      await signOut();
+    .catch(() => {
+      // A missing token here is usually a transient failed token refresh (a
+      // network blip during background polling). Return no headers so the
+      // caller skips this request and retries on its next poll, rather than
+      // forcing a logout. A genuine session loss is surfaced as a `signedOut`
+      // auth event and handled in the auth context.
+      return undefined;
     });
 
 export const getter = (props: FetcherProps) =>

--- a/frontend/components/externalLink/externalLink.tsx
+++ b/frontend/components/externalLink/externalLink.tsx
@@ -20,6 +20,7 @@ const ExternalLink: React.FC<ExternalLinkProps> = ({
       target="_blank"
       rel="noopener noreferrer"
       display={"inline"}
+      whiteSpace={"nowrap"}
       color={{ base: "blue.600", _dark: "white" }}
       textDecoration={"underline"}
       textDecorationColor={{ base: "blue.200", _dark: "whiteAlpha.400" }}

--- a/frontend/components/footer/footer.tsx
+++ b/frontend/components/footer/footer.tsx
@@ -26,6 +26,7 @@ export const Footer: FunctionComponent = () => {
         <ExternalLink
           href={"https://www.qut.edu.au/about/indigenous"}
           color={"white"}
+          whiteSpace={"normal"}
         >
           QUT acknowledges the Traditional Owners of the lands where QUT now
           stands.

--- a/frontend/components/mediaUpload/transcriptionOptions.tsx
+++ b/frontend/components/mediaUpload/transcriptionOptions.tsx
@@ -184,8 +184,7 @@ export const TranscriptionOptions: FunctionComponent<
             <Text>
               Translation only starts once transcription has finished, so allow
               at least 15 minutes for translated results to be ready. You
-              don&apos;t need to stay on this page while you wait, you can come
-              back to it later.
+              don&apos;t need to stay on this page while you wait.
             </Text>
             <Button
               size={"xs"}

--- a/frontend/components/mediaUpload/transcriptionOptions.tsx
+++ b/frontend/components/mediaUpload/transcriptionOptions.tsx
@@ -50,6 +50,8 @@ export const TranscriptionOptions: FunctionComponent<
   const [enablePiiRedaction, setEnablePiiRedaction] = useState<boolean>(false);
   const [generateSummary, setGenerateSummary] = useState<boolean>(true);
   const [enableTranslation, setEnableTranslation] = useState<boolean>(false);
+  const [translationWarningAcknowledged, setTranslationWarningAcknowledged] =
+    useState<boolean>(false);
   const [targetLanguage, setTargetLanguage] = useState<string | undefined>(
     "en",
   );
@@ -77,6 +79,7 @@ export const TranscriptionOptions: FunctionComponent<
     setEnableTranslation(d.checked);
     if (!d.checked) {
       setTargetLanguage(undefined);
+      setTranslationWarningAcknowledged(false);
     }
   };
 
@@ -148,27 +151,22 @@ export const TranscriptionOptions: FunctionComponent<
           </ChakraField.HelperText>
         )}
       </Field>
-      <NewFeature show={showNewFeature("ERP-4884")}>
-        <Field alignItems={"flex-start"} gap={1.5}>
-          <Heading as={"h3"} size={"md"}>
-            Translation Language
-          </Heading>
-          <Text fontSize={"sm"} color={"fg.muted"}>
-            This feature is powered by{" "}
-            <ExternalLink href={"https://aws.amazon.com/translate/"}>
-              Amazon Translate
-            </ExternalLink>
-            . Once your media is transcribed, the transcript can be
-            automatically translated into another language, with timed subtitles
-            (SRT/VTT), a document (DOCX) and plain text available to download.
-            Please be aware that machine translations may contain inaccuracies
-            and should be reviewed before being relied upon.
-          </Text>
-          <Text fontSize={"sm"} color={"fg.muted"}>
-            Translation runs after transcription has finished, so it takes
-            longer than transcription alone. Allow at least 15 minutes for
-            translated results to be ready.
-          </Text>
+      <Field alignItems={"flex-start"} gap={1.5}>
+        <Heading as={"h3"} size={"md"}>
+          Translation Language
+        </Heading>
+        <Text fontSize={"sm"} color={"fg.muted"}>
+          This feature is powered by{" "}
+          <ExternalLink href={"https://aws.amazon.com/translate/"}>
+            Amazon Translate
+          </ExternalLink>
+          . Once your media is transcribed, the transcript can be automatically
+          translated into another language, with timed subtitles (SRT/VTT), a
+          document (DOCX) and plain text available to download. Please be aware
+          that machine translations may contain inaccuracies and should be
+          reviewed before being relied upon.
+        </Text>
+        <NewFeature show={showNewFeature("ERP-4884")}>
           <Switch
             checked={enableTranslation}
             onCheckedChange={onEnableTranslationChange}
@@ -177,32 +175,53 @@ export const TranscriptionOptions: FunctionComponent<
           >
             Translate
           </Switch>
-          {enableTranslation && (
-            <Stack
-              direction={{ base: "column", sm: "row" }}
-              gap={{ base: 1.5, sm: 3 }}
-              align={{ base: "stretch", sm: "center" }}
-              width={"full"}
+        </NewFeature>
+        {enableTranslation && !translationWarningAcknowledged && (
+          <Alert
+            status={"warning"}
+            title={"Translations take longer than transcription."}
+          >
+            <Text>
+              Translation only starts once transcription has finished, so allow
+              at least 15 minutes for translated results to be ready. You
+              don&apos;t need to stay on this page while you wait, you can come
+              back to it later.
+            </Text>
+            <Button
+              size={"xs"}
+              colorPalette={"blue"}
+              mt={2}
+              onClick={() => setTranslationWarningAcknowledged(true)}
             >
-              <Text fontSize={"sm"} fontWeight={"medium"} whiteSpace={"nowrap"}>
-                Target language
-              </Text>
-              <Box minWidth={{ base: "auto", sm: "15rem" }} width={"full"}>
-                <TranslationLanguageInput
-                  value={targetLanguage}
-                  onChange={(value) => setTargetLanguage(value)}
-                  placeholder={"Select a language..."}
-                />
-              </Box>
-            </Stack>
-          )}
-          {enableTranslation && !targetLanguage && (
-            <ChakraField.HelperText whiteSpace={"nowrap"}>
-              Select a language to translate into.
-            </ChakraField.HelperText>
-          )}
-        </Field>
-      </NewFeature>
+              I understand
+            </Button>
+          </Alert>
+        )}
+        {enableTranslation && (
+          <Stack
+            direction={{ base: "column", sm: "row" }}
+            gap={{ base: 1.5, sm: 3 }}
+            align={{ base: "stretch", sm: "center" }}
+            width={"full"}
+          >
+            <Text fontSize={"sm"} fontWeight={"medium"} whiteSpace={"nowrap"}>
+              Target language
+            </Text>
+            <Box minWidth={{ base: "auto", sm: "15rem" }} width={"full"}>
+              <TranslationLanguageInput
+                value={targetLanguage}
+                onChange={(value) => setTargetLanguage(value)}
+                placeholder={"Select a language..."}
+              />
+            </Box>
+          </Stack>
+        )}
+        {enableTranslation && !targetLanguage && (
+          <ChakraField.HelperText whiteSpace={"nowrap"}>
+            Select a language to translate into.
+          </ChakraField.HelperText>
+        )}
+      </Field>
       <Field alignItems={"flex-start"} gap={1.5}>
         <Heading as={"h3"} size={"md"}>
           PII Redaction

--- a/frontend/components/newFeature/newFeature.tsx
+++ b/frontend/components/newFeature/newFeature.tsx
@@ -12,7 +12,7 @@ export const NewFeature: FunctionComponent<
   return show ? (
     <HStack
       pos={"relative"}
-      w={"full"}
+      w={"fit-content"}
       borderColor={"purple.300"}
       borderWidth={2}
       p={2}

--- a/frontend/components/transcriptionDownloadOptions/transcriptionDownloadOptions.tsx
+++ b/frontend/components/transcriptionDownloadOptions/transcriptionDownloadOptions.tsx
@@ -39,8 +39,32 @@ export interface DownloadOptionsProps
   ) => void;
 }
 
-const filenameFromFormat = (transcription: Transcription, format: string) =>
-  [transcription.metadata.filename.split(".")[0], format].join(".");
+interface DownloadVariant {
+  key: string;
+  label: string;
+  options: TranscriptOptions;
+}
+
+// Build a filename that includes the variant key, so the name always matches
+// the selected download metadata (plain/speakers/languages) and downloading
+// more than one variant of the same format doesn't collide and get a
+// browser-appended " (1)".
+const variantFilename = (
+  base: string,
+  format: string,
+  variant?: DownloadVariant,
+) => [variant ? `${base}-${variant.key}` : base, format].join(".");
+
+const filenameFromFormat = (
+  transcription: Transcription,
+  format: string,
+  variant?: DownloadVariant,
+) =>
+  variantFilename(
+    transcription.metadata.filename.split(".")[0],
+    format,
+    variant,
+  );
 
 const languageDisplayName = (code: string) =>
   (supportedTranslationLanguages as Record<string, string>)[code] ?? code;
@@ -48,12 +72,12 @@ const languageDisplayName = (code: string) =>
 const transcriptProps = (
   transcription: Transcription,
   format: TranscriptFormat,
-  options?: TranscriptOptions,
+  variant?: DownloadVariant,
 ) => ({
   objectKey: transcription.downloadKey!,
-  filename: filenameFromFormat(transcription, format),
+  filename: filenameFromFormat(transcription, format, variant),
   format,
-  options,
+  options: variant?.options,
 });
 
 const TRANSCRIPT_FORMATS: {
@@ -67,11 +91,7 @@ const TRANSCRIPT_FORMATS: {
   { format: "docx", label: "DOCX", icon: "docx" },
 ];
 
-const DOWNLOAD_VARIANTS: {
-  key: string;
-  label: string;
-  options: TranscriptOptions;
-}[] = [
+const DOWNLOAD_VARIANTS: DownloadVariant[] = [
   {
     key: "plain",
     label: "Plain",
@@ -158,12 +178,12 @@ export const TranscriptionDownloadOptions: FunctionComponent<
     originalLanguageNames && originalLanguageNames.length === 1
       ? `Original (${originalLanguageNames[0]})`
       : "Original transcript";
-  const translatedFilename = (format: string) =>
-    [
-      transcription.metadata.filename.split(".")[0],
-      targetLanguage,
+  const translatedFilename = (format: string, variant?: DownloadVariant) =>
+    variantFilename(
+      `${transcription.metadata.filename.split(".")[0]}-${targetLanguage}`,
       format,
-    ].join(".");
+      variant,
+    );
   const playUnavailable = isUndefined(transcription.downloadKey);
 
   const loadPlayer = (
@@ -267,11 +287,7 @@ export const TranscriptionDownloadOptions: FunctionComponent<
                           value={`${format}-${variant.key}`}
                           onClick={() =>
                             downloadTranscript(
-                              transcriptProps(
-                                transcription,
-                                format,
-                                variant.options,
-                              ),
+                              transcriptProps(transcription, format, variant),
                             )
                           }
                         >
@@ -307,7 +323,7 @@ export const TranscriptionDownloadOptions: FunctionComponent<
                             onClick={() =>
                               downloadTranslatedTranscript({
                                 objectKey: transcription.translationKey!,
-                                filename: translatedFilename(format),
+                                filename: translatedFilename(format, variant),
                                 format,
                                 options: variant.options,
                               })

--- a/frontend/context/auth-context.tsx
+++ b/frontend/context/auth-context.tsx
@@ -106,10 +106,17 @@ const AuthProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
     const handleAuthEvents = async (data: { payload: { event: string } }) => {
       const { event } = data.payload;
       switch (event) {
-        case "tokenRefresh_failure":
         case "signedOut":
           setState({ loading: false, authenticated: false, user: undefined });
           await router.push("/login");
+          break;
+        case "tokenRefresh_failure":
+          // A single failed silent token refresh is usually transient (e.g. a
+          // network blip while the page polls for job progress). Don't force a
+          // logout here: requests skip and retry, and Amplify refreshes again
+          // on the next attempt. A genuine session loss still arrives as a
+          // `signedOut` event and is handled above.
+          console.debug("Token refresh failed; will retry on next request");
           break;
         default:
           console.debug("Unhandled Auth Event:", event);

--- a/frontend/context/transcriptions-context.tsx
+++ b/frontend/context/transcriptions-context.tsx
@@ -37,7 +37,10 @@ export const TranscriptionsContextProvider: FunctionComponent<
     getter({ apiUrl: API_ENDPOINT, resource: "transcription" }).then((data) => {
       setState((current) => ({
         ...current,
-        transcriptions: data,
+        // A transient auth/token failure resolves `getter` to `undefined`; keep
+        // the current (initially empty) list rather than storing `undefined`,
+        // which would break consumers that read `transcriptions.length`.
+        transcriptions: data ?? current.transcriptions,
         transcriptionsLoading: false,
       }));
     });

--- a/frontend/context/transcriptions-context.tsx
+++ b/frontend/context/transcriptions-context.tsx
@@ -34,16 +34,24 @@ export const TranscriptionsContextProvider: FunctionComponent<
   });
 
   useEffect(() => {
-    getter({ apiUrl: API_ENDPOINT, resource: "transcription" }).then((data) => {
-      setState((current) => ({
-        ...current,
-        // A transient auth/token failure resolves `getter` to `undefined`; keep
-        // the current (initially empty) list rather than storing `undefined`,
-        // which would break consumers that read `transcriptions.length`.
-        transcriptions: data ?? current.transcriptions,
-        transcriptionsLoading: false,
-      }));
-    });
+    getter({ apiUrl: API_ENDPOINT, resource: "transcription" })
+      .then((data) => {
+        setState((current) => ({
+          ...current,
+          // A transient auth/token failure resolves `getter` to `undefined`;
+          // keep the current (initially empty) list rather than storing
+          // `undefined`, which would break consumers that read
+          // `transcriptions.length`.
+          transcriptions: data ?? current.transcriptions,
+          transcriptionsLoading: false,
+        }));
+      })
+      .catch((error) => {
+        // Network error or API rejection: clear the loading state so the page
+        // recovers (shows the empty state) instead of the spinner forever.
+        console.debug("Failed to load transcriptions", error);
+        setState((current) => ({ ...current, transcriptionsLoading: false }));
+      });
   }, []);
 
   return (


### PR DESCRIPTION
Addresses the QA testing feedback on [ERP-4928](https://eresearchqut.atlassian.net/browse/ERP-4928) from the translation/UI review.

## Changes

### Keep users signed in while waiting for translations
Testers were logged out while waiting for long-running translations. The cause was a single failed *silent token refresh* during the 5s progress-polling loop: `getHeaders` called `signOut()` on a momentarily missing token, and the auth context redirected to `/login` on the `tokenRefresh_failure` event. Both now treat a transient refresh failure as non-fatal, the request is skipped and retried on the next poll, and a genuine session loss still logs out via the `signedOut` event. No token-lifetime/timeout values were changed.

### Make the translation option clearer
Testers missed the translate toggle and were surprised by how long translation takes.
- The "New" highlight border now hugs just the toggle instead of the whole field.
- A warning alert (styled like the PII-redaction warning, with an **I understand** button) appears when translation is enabled, explaining it starts after transcription and can take 15+ minutes.

| New border on the toggle | Warning + "I understand" |
|---|---|
| ![New border on toggle](https://gist.githubusercontent.com/ScriptSmith/686860bfcf9a6739a8e3ddc7f599dae8/raw/5271ddaf8e599dcbfe3d8d67d000b10c4fc6d50d/new-border-toggle.png) | ![Translation warning](https://gist.githubusercontent.com/ScriptSmith/686860bfcf9a6739a8e3ddc7f599dae8/raw/5271ddaf8e599dcbfe3d8d67d000b10c4fc6d50d/translation-warning.png) |

Enabled, with the target-language selector:

![Translation enabled](https://gist.githubusercontent.com/ScriptSmith/686860bfcf9a6739a8e3ddc7f599dae8/raw/5271ddaf8e599dcbfe3d8d67d000b10c4fc6d50d/translation-enabled.png)

### Distinct, consistent download filenames
Downloading more than one variant of the same format (plain, with speakers, etc.) produced identical filenames, so the browser appended ` (1)`. Filenames now derive their suffix from the variant definition, and use `-` consistently for every part (including the translation language) so all downloads have a single extension dot:

| Variant | Regular | Translation (fr) |
|---|---|---|
| plain | `name-plain.txt` | `name-fr-plain.txt` |
| with speakers | `name-speakers.txt` | `name-fr-speakers.txt` |
| with speakers & languages | `name-speakers-languages.txt` | — |

### Stop inline links wrapping mid-phrase
`ExternalLink` now defaults to `white-space: nowrap` so paragraph links (and their trailing external-link icon) stay on one line. The footer Acknowledgement of Country link is overridden back to normal wrapping so it stays fully visible.

## Testing
- `biome check` clean on all changed files
- `frontend` and `deployment` typecheck pass


[ERP-4928]: https://eresearchqut.atlassian.net/browse/ERP-4928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ