### PR TITLE
[ERP-4965] Record a permanent audit log of transcription usage

### DIFF
--- a/api/jest-dynalite-config.js
+++ b/api/jest-dynalite-config.js
@@ -17,6 +17,51 @@ module.exports = {
       },
       data: [],
     },
+    {
+      TableName: "transcription-usage",
+      KeySchema: [
+        { AttributeName: "pk", KeyType: "HASH" },
+        { AttributeName: "sk", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "pk", AttributeType: "S" },
+        { AttributeName: "sk", AttributeType: "S" },
+        { AttributeName: "rpid", AttributeType: "S" },
+        { AttributeName: "usageMonth", AttributeType: "S" },
+        { AttributeName: "startedAt", AttributeType: "S" },
+      ],
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: "byRpid",
+          KeySchema: [
+            { AttributeName: "rpid", KeyType: "HASH" },
+            { AttributeName: "startedAt", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "ALL" },
+          ProvisionedThroughput: {
+            ReadCapacityUnits: 1,
+            WriteCapacityUnits: 1,
+          },
+        },
+        {
+          IndexName: "byPeriod",
+          KeySchema: [
+            { AttributeName: "usageMonth", KeyType: "HASH" },
+            { AttributeName: "startedAt", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "ALL" },
+          ProvisionedThroughput: {
+            ReadCapacityUnits: 1,
+            WriteCapacityUnits: 1,
+          },
+        },
+      ],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1,
+      },
+      data: [],
+    },
   ],
   basePort: 8000,
 };

--- a/api/src/client/bedrockClient.ts
+++ b/api/src/client/bedrockClient.ts
@@ -11,11 +11,19 @@ const ANTHROPIC_VERSION = process.env.ANTHROPIC_VERSION ?? "bedrock-2023-05-31";
 const BEDROCK_MODEL_ID =
   process.env.BEDROCK_MODEL_ID ?? "anthropic.claude-3-haiku-20240307-v1:0";
 
+export interface ModelInvocation {
+  text: string;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+  };
+}
+
 export const invokeModel = async (
   client: BedrockRuntimeClient,
   prompt: string,
   modelId: string = BEDROCK_MODEL_ID,
-): Promise<string> => {
+): Promise<ModelInvocation> => {
   // Prepare the payload for the model.
   const payload = {
     anthropic_version: ANTHROPIC_VERSION,
@@ -38,5 +46,12 @@ export const invokeModel = async (
 
   // Decode and return the response(s)
   const responseBody = JSON.parse(new TextDecoder().decode(apiResponse.body));
-  return responseBody.content[0].text;
+  const { input_tokens: inputTokens, output_tokens: outputTokens } =
+    responseBody.usage ?? {};
+  return {
+    text: responseBody.content[0].text,
+    ...(inputTokens !== undefined || outputTokens !== undefined
+      ? { usage: { inputTokens, outputTokens } }
+      : {}),
+  };
 };

--- a/api/src/event/copyOutputHandler.ts
+++ b/api/src/event/copyOutputHandler.ts
@@ -1,16 +1,44 @@
-import { CopyObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  CopyObjectCommand,
+  GetObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
 
 import type { S3Handler } from "aws-lambda";
 import xray from "aws-xray-sdk";
 
 import { downloadKey } from "../service/transcriptionService";
+import {
+  type TranscriptDocument,
+  transcriptDurationSeconds,
+} from "../util/transcript";
 
 const region = process.env.AWS_REGION || "ap-southeast-2";
 const outputPattern = /^transcription\/([^/]+)\/([^/]+)$/;
 
 const s3Client = new S3Client({ region });
 
-xray.captureAWSv3Client(s3Client);
+if (process.env.NODE_ENV !== "test") {
+  xray.captureAWSv3Client(s3Client);
+}
+
+const measureAudioSeconds = async (
+  bucketName: string,
+  key: string,
+): Promise<number | undefined> => {
+  try {
+    const raw = await s3Client
+      .send(new GetObjectCommand({ Bucket: bucketName, Key: key }))
+      .then((result) => result.Body?.transformToString());
+    if (!raw) {
+      return undefined;
+    }
+    return transcriptDurationSeconds(JSON.parse(raw) as TranscriptDocument);
+  } catch (e) {
+    console.error(`Failed to measure the duration of ${key} because: ${e}`, e);
+    return undefined;
+  }
+};
 
 export const handler: S3Handler = async (event) => {
   for (const record of event.Records) {
@@ -31,7 +59,8 @@ export const handler: S3Handler = async (event) => {
             Key: usersKey,
           }),
         );
-        await downloadKey(identityId, jobId, usersKey);
+        const audioSeconds = await measureAudioSeconds(bucketName, key);
+        await downloadKey(identityId, jobId, usersKey, audioSeconds);
       } catch (e) {
         console.error(`Failed to copy ${key} to ${usersKey} because: ${e}`, e);
       }

--- a/api/src/event/fileUploadHandler.ts
+++ b/api/src/event/fileUploadHandler.ts
@@ -10,6 +10,7 @@ import {
 
 import type { S3Event } from "aws-lambda";
 import xray from "aws-xray-sdk";
+import type { Rpid } from "model";
 
 import { getRpid } from "../client/dmpClient";
 import { jobRejected, jobStarted } from "../service/transcriptionService";
@@ -70,8 +71,9 @@ export const handler = async (event: S3Event) => {
         );
         continue;
       }
+      let rpidPayload: Rpid;
       try {
-        await getRpid(identityId, rpid);
+        rpidPayload = await getRpid(identityId, rpid);
       } catch (error) {
         console.error(`Failed to validate rpid ${rpid}`, error);
         await jobRejected(
@@ -147,6 +149,7 @@ export const handler = async (event: S3Event) => {
           record.s3,
           transcriptionResponse,
           headResponse.Metadata,
+          rpidPayload as unknown as Record<string, unknown>,
         ).then(() => uploadsCount++);
       } catch (error) {
         console.error("Failed to save job details", error);

--- a/api/src/event/summariseTranscriptionHandler.ts
+++ b/api/src/event/summariseTranscriptionHandler.ts
@@ -80,16 +80,16 @@ export const handler = async (event: S3Event) => {
                   `${GENERATE_SUMMARY_PROMPT} <transcript>${transcript}</transcript> ${NO_PREAMBLE_PROMPT}`,
                 ),
               )
-              .then((summary: string) =>
-                s3Client.send(
+              .then(async ({ text, usage }) => {
+                await s3Client.send(
                   new PutObjectCommand({
                     Bucket: bucketName,
                     Key: summaryKey,
-                    Body: summary,
+                    Body: text,
                   }),
-                ),
-              )
-              .then(() => updateSummaryKey(identityId, jobId, summaryKey));
+                );
+                return updateSummaryKey(identityId, jobId, summaryKey, usage);
+              });
           } else {
             return Promise.resolve({});
           }

--- a/api/src/event/translateStartHandler.ts
+++ b/api/src/event/translateStartHandler.ts
@@ -128,21 +128,27 @@ export const handler = async (event: { detail?: TranscriptionJob }) => {
       }),
     );
     await updateTranslationKey(identityId, jobId, translationOutputKey);
-    await updateTranslationJob(identityId, jobId, {
-      jobId: "",
-      status: "COMPLETED",
-    });
+    await updateTranslationJob(
+      identityId,
+      jobId,
+      {
+        jobId: "",
+        status: "COMPLETED",
+      },
+      0,
+    );
     return "Source language matches target; copied original transcript";
   }
 
   // Write the segments as an XLIFF document and start an asynchronous batch
   // translation job. Completion is handled by translateJobStateChangeHandler.
   const transcript: TranscriptDocument = JSON.parse(transcriptRaw);
-  const xliff = buildXliff(
-    segmentTexts(transcript),
-    sourceLanguage,
-    targetLanguage,
+  const segments = segmentTexts(transcript);
+  const translationCharacters = segments.reduce(
+    (total, text) => total + text.length,
+    0,
   );
+  const xliff = buildXliff(segments, sourceLanguage, targetLanguage);
   const inputPrefix = `translations/input/${identityId}/${jobId}/`;
   await s3Client.send(
     new PutObjectCommand({
@@ -188,10 +194,15 @@ export const handler = async (event: { detail?: TranscriptionJob }) => {
     return "Failed to start translation job";
   }
 
-  await updateTranslationJob(identityId, jobId, {
-    jobId: startResponse.JobId ?? "",
-    status: startResponse.JobStatus ?? "SUBMITTED",
-  });
+  await updateTranslationJob(
+    identityId,
+    jobId,
+    {
+      jobId: startResponse.JobId ?? "",
+      status: startResponse.JobStatus ?? "SUBMITTED",
+    },
+    translationCharacters,
+  );
 
   return `Started translation job ${startResponse.JobId} (${sourceLanguage} -> ${targetLanguage})`;
 };

--- a/api/src/event/usageProjectionHandler.ts
+++ b/api/src/event/usageProjectionHandler.ts
@@ -1,0 +1,69 @@
+import type { AttributeValue } from "@aws-sdk/client-dynamodb";
+import { unmarshall } from "@aws-sdk/util-dynamodb";
+
+import type {
+  DynamoDBBatchResponse,
+  DynamoDBRecord,
+  DynamoDBStreamEvent,
+} from "aws-lambda";
+import type { Transcription } from "model";
+
+import {
+  markUsageRecordExpired,
+  putUsageRecord,
+} from "../repository/usageRepository";
+import { toUsageRecord } from "../service/usageService";
+
+export const handler = async (
+  event: DynamoDBStreamEvent,
+): Promise<DynamoDBBatchResponse> => {
+  const batchItemFailures: DynamoDBBatchResponse["batchItemFailures"] = [];
+
+  for (const record of event.Records) {
+    try {
+      await project(record);
+    } catch (error) {
+      console.error("Failed to project usage record", {
+        error,
+        eventId: record.eventID,
+      });
+      if (record.dynamodb?.SequenceNumber) {
+        batchItemFailures.push({
+          itemIdentifier: record.dynamodb.SequenceNumber,
+        });
+      }
+    }
+  }
+
+  return { batchItemFailures };
+};
+
+const project = async (record: DynamoDBRecord) => {
+  const expired = record.eventName === "REMOVE";
+  const image = expired ? record.dynamodb?.OldImage : record.dynamodb?.NewImage;
+  if (!image) {
+    return;
+  }
+
+  const transcription = unmarshall(
+    image as Record<string, AttributeValue>,
+  ) as Transcription;
+  if (!transcription.pk || !transcription.sk) {
+    console.error("Skipping record with no key", { eventId: record.eventID });
+    return;
+  }
+
+  const usageRecord = toUsageRecord(transcription);
+  await putUsageRecord(usageRecord);
+
+  if (expired) {
+    await markUsageRecordExpired(
+      usageRecord.pk,
+      usageRecord.sk,
+      new Date(
+        (record.dynamodb?.ApproximateCreationDateTime ?? Date.now() / 1000) *
+          1000,
+      ).toISOString(),
+    );
+  }
+};

--- a/api/src/repository/repository.ts
+++ b/api/src/repository/repository.ts
@@ -44,27 +44,33 @@ export const putResource = (
     }),
   );
 
-export const updateResource = (
+export const updateResources = (
   pk: string,
   sk: string,
-  attributeName: string,
-  attributeValue: string | object,
-) =>
-  dynamoDBClient.send(
+  attributes: Record<string, string | number | object | undefined>,
+) => {
+  const entries = Object.entries(attributes).filter(
+    ([, value]) => value !== undefined,
+  );
+  const assignments = entries.map((_, index) => `#n${index} = :v${index}`);
+  return dynamoDBClient.send(
     new UpdateItemCommand({
       TableName: tableName,
       Key: marshall({ pk, sk }),
       ReturnValues: "UPDATED_NEW",
-      UpdateExpression:
-        "set #attributeName = :attributeValue, #date = :date, #ttl = :ttl",
+      UpdateExpression: `set ${[...assignments, "#date = :date", "#ttl = :ttl"].join(", ")}`,
       ExpressionAttributeNames: {
-        "#attributeName": attributeName,
+        ...Object.fromEntries(
+          entries.map(([name], index) => [`#n${index}`, name]),
+        ),
         "#date": "date",
         "#ttl": "ttl",
       },
       ExpressionAttributeValues: marshall(
         {
-          ":attributeValue": attributeValue,
+          ...Object.fromEntries(
+            entries.map(([, value], index) => [`:v${index}`, value]),
+          ),
           ":date": new Date().toISOString(),
           ":ttl": Math.floor(Date.now() / 1000) + TTL_DELTA,
         },
@@ -72,6 +78,14 @@ export const updateResource = (
       ),
     }),
   );
+};
+
+export const updateResource = (
+  pk: string,
+  sk: string,
+  attributeName: string,
+  attributeValue: string | object,
+) => updateResources(pk, sk, { [attributeName]: attributeValue });
 
 export const deleteResource = (pk: string, sk: string) =>
   dynamoDBClient.send(

--- a/api/src/repository/usageRepository.ts
+++ b/api/src/repository/usageRepository.ts
@@ -1,0 +1,79 @@
+import {
+  ConditionalCheckFailedException,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import { marshall } from "@aws-sdk/util-dynamodb";
+
+import type { UsageRecord } from "model";
+
+import dynamoDBClient from "./dynamoDBClient";
+
+const usageTableName = process.env.USAGE_TABLE_NAME || "transcription-usage";
+
+const WRITE_ONCE_ATTRIBUTES = new Set([
+  "startedAt",
+  "usageMonth",
+  "completedAt",
+]);
+
+export const putUsageRecord = async (record: UsageRecord) => {
+  const { pk, sk, updatedAt, ...attributes } = record;
+  const entries = Object.entries(attributes).filter(
+    ([, value]) => value !== undefined,
+  );
+
+  const assignments = entries.map(([name], index) =>
+    WRITE_ONCE_ATTRIBUTES.has(name)
+      ? `#n${index} = if_not_exists(#n${index}, :v${index})`
+      : `#n${index} = :v${index}`,
+  );
+
+  try {
+    await dynamoDBClient.send(
+      new UpdateItemCommand({
+        TableName: usageTableName,
+        Key: marshall({ pk, sk }),
+        UpdateExpression: `set ${[...assignments, "#updatedAt = :updatedAt"].join(", ")}`,
+        ConditionExpression:
+          "attribute_not_exists(#updatedAt) or #updatedAt <= :updatedAt",
+        ExpressionAttributeNames: {
+          ...Object.fromEntries(
+            entries.map(([name], index) => [`#n${index}`, name]),
+          ),
+          "#updatedAt": "updatedAt",
+        },
+        ExpressionAttributeValues: marshall(
+          {
+            ...Object.fromEntries(
+              entries.map(([, value], index) => [`:v${index}`, value]),
+            ),
+            ":updatedAt": updatedAt,
+          },
+          { removeUndefinedValues: true },
+        ),
+      }),
+    );
+  } catch (error) {
+    if (error instanceof ConditionalCheckFailedException) {
+      console.log(`Skipped stale usage projection for ${pk} ${sk}`);
+      return;
+    }
+    throw error;
+  }
+};
+
+export const markUsageRecordExpired = (
+  pk: string,
+  sk: string,
+  expiredAt: string,
+) =>
+  dynamoDBClient.send(
+    new UpdateItemCommand({
+      TableName: usageTableName,
+      Key: marshall({ pk, sk }),
+      UpdateExpression:
+        "set #expiredAt = if_not_exists(#expiredAt, :expiredAt)",
+      ExpressionAttributeNames: { "#expiredAt": "expiredAt" },
+      ExpressionAttributeValues: marshall({ ":expiredAt": expiredAt }),
+    }),
+  );

--- a/api/src/service/transcriptionService.ts
+++ b/api/src/service/transcriptionService.ts
@@ -5,6 +5,7 @@ import {
   getResources,
   putResource,
   updateResource,
+  updateResources,
 } from "../repository/repository";
 
 export const normaliseJobId = (jobId: string): string =>
@@ -17,12 +18,16 @@ export const jobStarted = (
   uploadEvent: Record<string, unknown>,
   transcriptionResponse: StartTranscriptionJobResponse,
   metadata: Record<string, unknown>,
+  rpidPayload?: Record<string, unknown>,
 ) =>
   putResource(identityId, jobId, {
     outputKey,
     uploadEvent: JSON.parse(JSON.stringify(uploadEvent)),
     transcriptionResponse: JSON.parse(JSON.stringify(transcriptionResponse)),
     metadata: JSON.parse(JSON.stringify(metadata)),
+    ...(rpidPayload && {
+      rpidPayload: JSON.parse(JSON.stringify(rpidPayload)),
+    }),
   });
 
 export const jobRejected = (
@@ -59,15 +64,23 @@ export const downloadKey = (
   identityId: string,
   jobId: string,
   downloadKey: string,
+  audioSeconds?: number,
 ) =>
-  updateResource(identityId, normaliseJobId(jobId), "downloadKey", downloadKey);
+  updateResources(identityId, normaliseJobId(jobId), {
+    downloadKey,
+    audioSeconds,
+  });
 
 export const summaryKey = (
   identityId: string,
   jobId: string,
   summaryKey: string,
+  summaryUsage?: { inputTokens?: number; outputTokens?: number },
 ) =>
-  updateResource(identityId, normaliseJobId(jobId), "summaryKey", summaryKey);
+  updateResources(identityId, normaliseJobId(jobId), {
+    summaryKey,
+    summaryUsage,
+  });
 
 export const translationKey = (
   identityId: string,
@@ -85,13 +98,12 @@ export const translationJob = (
   identityId: string,
   jobId: string,
   translationJob: { jobId: string; status: string; message?: string },
+  translationCharacters?: number,
 ) =>
-  updateResource(
-    identityId,
-    normaliseJobId(jobId),
-    "translationJob",
+  updateResources(identityId, normaliseJobId(jobId), {
     translationJob,
-  );
+    translationCharacters,
+  });
 
 export const getTranscriptions = (identityId: string) =>
   getResources(identityId);

--- a/api/src/service/usageService.ts
+++ b/api/src/service/usageService.ts
@@ -1,0 +1,73 @@
+import {
+  mapTranscriptionStatus,
+  type Transcription,
+  type UsageRecord,
+  usagePartitionKey,
+  usageSortKey,
+} from "model";
+
+const TERMINAL_STATUSES = ["COMPLETED", "FAILED"];
+
+const parseBoolean = (value?: string): boolean => {
+  try {
+    return !!value && JSON.parse(value.toLowerCase()) === true;
+  } catch {
+    return false;
+  }
+};
+
+const splitLanguages = (value?: string): string[] | undefined => {
+  const languages = (value ?? "")
+    .split(/,\s?/)
+    .map((language) => language.trim())
+    .filter(Boolean);
+  return languages.length > 0 ? languages : undefined;
+};
+
+const resolvedLanguage = (record: Transcription): string | undefined => {
+  const job = record.transcriptionResponse?.TranscriptionJob;
+  return job?.LanguageCode ?? job?.LanguageCodes?.[0]?.LanguageCode;
+};
+
+export const toUsageRecord = (record: Transcription): UsageRecord => {
+  const metadata = record.metadata ?? ({} as Transcription["metadata"]);
+  const status = mapTranscriptionStatus(record);
+  const timestamp = record.date ?? new Date().toISOString();
+
+  return {
+    pk: usagePartitionKey(record.pk),
+    sk: usageSortKey(record.sk),
+    identityId: record.pk,
+    jobId: record.sk,
+
+    rpid: metadata.rpid || undefined,
+    rpidPayload: record.rpidPayload,
+
+    sourceLanguages: splitLanguages(metadata.languages),
+    resolvedLanguage: resolvedLanguage(record),
+    targetLanguage: metadata.targetlanguage || undefined,
+    mimeType: metadata.mimetype || undefined,
+
+    piiRedaction: parseBoolean(metadata.enablepiiredaction),
+    summaryRequested: parseBoolean(metadata.generatesummary),
+    translationRequested: !!metadata.targetlanguage,
+
+    bytesUploaded: record.uploadEvent?.object?.size,
+    audioSeconds: record.audioSeconds,
+    summaryInputTokens: record.summaryUsage?.inputTokens,
+    summaryOutputTokens: record.summaryUsage?.outputTokens,
+    translationCharacters: record.translationCharacters,
+
+    status,
+    failureReason: record.jobStatusUpdated?.detail.FailureReason,
+    translationStatus: record.translationJob?.status,
+    translationFailureReason: record.translationJob?.message,
+
+    usageMonth: timestamp.slice(0, 7),
+    startedAt: timestamp,
+    updatedAt: timestamp,
+    ...(status && TERMINAL_STATUSES.includes(status)
+      ? { completedAt: timestamp }
+      : {}),
+  };
+};

--- a/api/src/util/transcript.ts
+++ b/api/src/util/transcript.ts
@@ -27,6 +27,35 @@ export const segmentTexts = (doc: TranscriptDocument): string[] =>
     (segment) => segment.alternatives?.[0]?.transcript ?? "",
   );
 
+export const translationCharacterCount = (doc: TranscriptDocument): number =>
+  segmentTexts(doc).reduce((total, text) => total + text.length, 0);
+
+export const transcriptDurationSeconds = (
+  doc: TranscriptDocument,
+): number | undefined => {
+  const timed = [
+    doc.results.segments,
+    doc.results.items,
+    (doc.results as { audio_segments?: unknown }).audio_segments,
+  ];
+  let longest: number | undefined;
+  for (const entries of timed) {
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+    for (const entry of entries) {
+      const endTime = Number((entry as { end_time?: string })?.end_time);
+      if (
+        Number.isFinite(endTime) &&
+        (longest === undefined || endTime > longest)
+      ) {
+        longest = endTime;
+      }
+    }
+  }
+  return longest;
+};
+
 /**
  * Rebuild a Transcribe-shaped document with translated segment text, keyed by
  * segment index. Segment timings and speaker labels are preserved; the full

--- a/api/test/event/copyOutputHandler.test.ts
+++ b/api/test/event/copyOutputHandler.test.ts
@@ -1,0 +1,87 @@
+import {
+  CopyObjectCommand,
+  GetObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { sdkStreamMixin } from "@smithy/util-stream";
+
+import type { S3Event } from "aws-lambda";
+import { mockClient } from "aws-sdk-client-mock";
+import "aws-sdk-client-mock-jest";
+import { Readable } from "node:stream";
+import type { Transcription } from "model";
+
+import { handler } from "../../src/event/copyOutputHandler";
+import { getResource } from "../../src/repository/repository";
+
+const identityId = "76c65a59-1c57-489b-be96-020ceaa9675a";
+const jobId = "2e9b38b5-1df0-4841-8308-f174fb88aac7";
+const bucket = "local-transcriptions";
+
+const transcript = {
+  results: {
+    transcripts: [{ transcript: "Hello world." }],
+    segments: [
+      {
+        start_time: "0.0",
+        end_time: "612.5",
+        alternatives: [{ transcript: "Hello world." }],
+      },
+    ],
+  },
+};
+
+const event = (key: string) =>
+  ({
+    Records: [{ s3: { bucket: { name: bucket }, object: { key } } }],
+  }) as S3Event;
+
+describe("copyOutputHandler", () => {
+  const s3ClientMock = mockClient(S3Client);
+
+  beforeEach(() => {
+    s3ClientMock.reset();
+    s3ClientMock.on(CopyObjectCommand).resolves({});
+    s3ClientMock.on(GetObjectCommand).resolves({
+      Body: sdkStreamMixin(Readable.from(JSON.stringify(transcript))),
+    } as never);
+  });
+
+  it("copies the output and records the audio duration", async () => {
+    await handler(
+      event(`transcription/${identityId}/${jobId}.json`),
+      {} as never,
+      {} as never,
+    );
+
+    expect(s3ClientMock).toHaveReceivedCommandWith(CopyObjectCommand, {
+      Bucket: bucket,
+      CopySource: `${bucket}/transcription/${identityId}/${jobId}.json`,
+      Key: `users/${identityId}/${jobId}.json`,
+    });
+
+    const record = (await getResource(identityId, jobId)) as Transcription;
+    expect(record.downloadKey).toEqual(`users/${identityId}/${jobId}.json`);
+    expect(record.audioSeconds).toEqual(612.5);
+  });
+
+  it("still records the download key when the duration cannot be measured", async () => {
+    s3ClientMock.on(GetObjectCommand).rejects(new Error("AccessDenied"));
+
+    await handler(
+      event(`transcription/${identityId}/${jobId}.json`),
+      {} as never,
+      {} as never,
+    );
+
+    const record = (await getResource(identityId, jobId)) as Transcription;
+    expect(record.downloadKey).toEqual(`users/${identityId}/${jobId}.json`);
+    expect(record.audioSeconds).toBeUndefined();
+  });
+
+  it("ignores an unexpected key", async () => {
+    await handler(event("somewhere/else.json"), {} as never, {} as never);
+
+    expect(s3ClientMock).not.toHaveReceivedCommand(CopyObjectCommand);
+  });
+});

--- a/api/test/event/fileUploadHandler.test.ts
+++ b/api/test/event/fileUploadHandler.test.ts
@@ -58,9 +58,13 @@ describe("fileUploadHandler", () => {
     s3Mock.on(HeadObjectCommand).resolves({
       Metadata: { ...fileMetadata.Metadata, rpid: RPID },
     });
-    fetchMock
-      .mockResolvedValueOnce(tokenResponse)
-      .mockResolvedValueOnce(jsonResponse(200, { encodedId: RPID }));
+    fetchMock.mockResolvedValueOnce(tokenResponse).mockResolvedValueOnce(
+      jsonResponse(200, {
+        encodedId: RPID,
+        title: "My Research Project",
+        organisation: "Faculty of Science",
+      }),
+    );
 
     expect(await handler(fileUploadEvent)).toEqual("Processed 1 uploads");
 
@@ -78,6 +82,11 @@ describe("fileUploadHandler", () => {
     expect(await getResource(IDENTITY_ID, JOB_ID)).toEqual(
       expect.objectContaining({
         metadata: expect.objectContaining({ rpid: RPID }),
+        rpidPayload: {
+          encodedId: RPID,
+          title: "My Research Project",
+          organisation: "Faculty of Science",
+        },
       }),
     );
   });

--- a/api/test/event/summariseTranscriptionHandler.test.ts
+++ b/api/test/event/summariseTranscriptionHandler.test.ts
@@ -85,6 +85,7 @@ describe("summariseTranscriptionHandler", () => {
         Buffer.from(
           JSON.stringify({
             content: [{ text: "dummy output transcription summary" }],
+            usage: { input_tokens: 900, output_tokens: 120 },
           }),
         ),
       ),
@@ -145,5 +146,9 @@ describe("summariseTranscriptionHandler", () => {
       "2e9b38b5-1df0-4841-8308-f174fb88aac7",
     )) as Transcription;
     expect(transcription.summaryKey).toEqual(expectedSummaryKey);
+    expect(transcription.summaryUsage).toEqual({
+      inputTokens: 900,
+      outputTokens: 120,
+    });
   });
 });

--- a/api/test/event/translateStartHandler.test.ts
+++ b/api/test/event/translateStartHandler.test.ts
@@ -121,6 +121,7 @@ describe("translateStartHandler", () => {
       jobId: "tjid",
       status: "SUBMITTED",
     });
+    expect(record.translationCharacters).toEqual(24);
   });
 
   test("copies the original transcript when source equals target", async () => {
@@ -144,6 +145,7 @@ describe("translateStartHandler", () => {
       `users/${identityId}/translations/${jobId}/en`,
     );
     expect(record.translationJob?.status).toEqual("COMPLETED");
+    expect(record.translationCharacters).toEqual(0);
   });
 
   test("persists FAILED when the source language is not supported by Translate", async () => {

--- a/api/test/event/usageProjectionHandler.test.ts
+++ b/api/test/event/usageProjectionHandler.test.ts
@@ -1,0 +1,217 @@
+import { GetItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
+
+import type { DynamoDBRecord, DynamoDBStreamEvent } from "aws-lambda";
+import type { UsageRecord } from "model";
+
+import { handler } from "../../src/event/usageProjectionHandler";
+import dynamoDBClient from "../../src/repository/dynamoDBClient";
+
+const usageTableName = process.env.USAGE_TABLE_NAME || "transcription-usage";
+
+const IDENTITY_ID = "76c65a59-1c57-489b-be96-020ceaa9675a";
+const JOB_ID = "2e9b38b5-1df0-4841-8308-f174fb88aac7";
+
+const transcriptionRecord = (overrides: Record<string, unknown> = {}) => ({
+  pk: IDENTITY_ID,
+  sk: JOB_ID,
+  date: "2026-08-06T01:02:03.000Z",
+  metadata: {
+    filename: "Welcome.wav",
+    filetype: "userUploadedFile",
+    mimetype: "audio/wav",
+    languages: "en-AU",
+    enablepiiredaction: "false",
+    generatesummary: "false",
+    rpid: "RPID-1234",
+  },
+  uploadEvent: { object: { key: "users/x/y.upload", size: 1292288 } },
+  ...overrides,
+});
+
+const APPROXIMATE_CREATION_TIME = 1786000000;
+
+const streamRecord = (
+  eventName: DynamoDBRecord["eventName"],
+  image: Record<string, unknown>,
+  sequenceNumber = "1",
+): DynamoDBRecord => ({
+  eventID: `event-${sequenceNumber}`,
+  eventName,
+  dynamodb: {
+    SequenceNumber: sequenceNumber,
+    ApproximateCreationDateTime: APPROXIMATE_CREATION_TIME,
+    ...(eventName === "REMOVE"
+      ? { OldImage: marshall(image) }
+      : { NewImage: marshall(image) }),
+  },
+});
+
+const event = (...records: DynamoDBRecord[]) =>
+  ({ Records: records }) as DynamoDBStreamEvent;
+
+const getUsageRecord = () =>
+  dynamoDBClient
+    .send(
+      new GetItemCommand({
+        TableName: usageTableName,
+        Key: marshall({ pk: `USER#${IDENTITY_ID}`, sk: `JOB#${JOB_ID}` }),
+      }),
+    )
+    .then(({ Item }) => Item && (unmarshall(Item) as UsageRecord));
+
+describe("usageProjectionHandler", () => {
+  it("projects a new transcription record into the usage table", async () => {
+    const result = await handler(
+      event(streamRecord("INSERT", transcriptionRecord())),
+    );
+
+    expect(result.batchItemFailures).toEqual([]);
+    expect(await getUsageRecord()).toEqual(
+      expect.objectContaining({
+        identityId: IDENTITY_ID,
+        jobId: JOB_ID,
+        rpid: "RPID-1234",
+        bytesUploaded: 1292288,
+        usageMonth: "2026-08",
+        startedAt: "2026-08-06T01:02:03.000Z",
+      }),
+    );
+  });
+
+  it("accumulates metered units as the job progresses", async () => {
+    await handler(event(streamRecord("INSERT", transcriptionRecord())));
+    await handler(
+      event(
+        streamRecord(
+          "MODIFY",
+          transcriptionRecord({
+            date: "2026-08-06T01:30:00.000Z",
+            audioSeconds: 612.5,
+            jobStatusUpdated: {
+              detail: { TranscriptionJobStatus: "COMPLETED" },
+            },
+          }),
+          "2",
+        ),
+      ),
+    );
+
+    const record = await getUsageRecord();
+    expect(record).toEqual(
+      expect.objectContaining({
+        audioSeconds: 612.5,
+        status: "COMPLETED",
+        completedAt: "2026-08-06T01:30:00.000Z",
+        updatedAt: "2026-08-06T01:30:00.000Z",
+        startedAt: "2026-08-06T01:02:03.000Z",
+      }),
+    );
+  });
+
+  it("ignores a redelivered older state", async () => {
+    await handler(
+      event(
+        streamRecord(
+          "INSERT",
+          transcriptionRecord({
+            date: "2026-08-06T01:30:00.000Z",
+            audioSeconds: 612.5,
+            jobStatusUpdated: {
+              detail: { TranscriptionJobStatus: "COMPLETED" },
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = await handler(
+      event(streamRecord("MODIFY", transcriptionRecord(), "2")),
+    );
+
+    expect(result.batchItemFailures).toEqual([]);
+    const record = await getUsageRecord();
+    expect(record?.status).toEqual("COMPLETED");
+    expect(record?.audioSeconds).toEqual(612.5);
+  });
+
+  it("keeps the usage record when the transcription record expires", async () => {
+    await handler(event(streamRecord("INSERT", transcriptionRecord())));
+    await handler(
+      event(
+        streamRecord(
+          "REMOVE",
+          transcriptionRecord({
+            date: "2026-08-20T01:02:03.000Z",
+            audioSeconds: 612.5,
+          }),
+          "2",
+        ),
+      ),
+    );
+
+    const record = await getUsageRecord();
+    expect(record?.audioSeconds).toEqual(612.5);
+    expect(record?.expiredAt).toEqual(
+      new Date(APPROXIMATE_CREATION_TIME * 1000).toISOString(),
+    );
+  });
+
+  it("is queryable by research project after the job has expired", async () => {
+    await handler(event(streamRecord("INSERT", transcriptionRecord())));
+    await handler(event(streamRecord("REMOVE", transcriptionRecord(), "2")));
+
+    const { Items } = await dynamoDBClient.send(
+      new QueryCommand({
+        TableName: usageTableName,
+        IndexName: "byRpid",
+        KeyConditionExpression: "#rpid = :rpid",
+        ExpressionAttributeNames: { "#rpid": "rpid" },
+        ExpressionAttributeValues: marshall({ ":rpid": "RPID-1234" }),
+      }),
+    );
+
+    expect(Items).toHaveLength(1);
+    expect(unmarshall(Items![0])).toEqual(
+      expect.objectContaining({ jobId: JOB_ID }),
+    );
+  });
+
+  it("is queryable by reporting period", async () => {
+    await handler(event(streamRecord("INSERT", transcriptionRecord())));
+
+    const { Items } = await dynamoDBClient.send(
+      new QueryCommand({
+        TableName: usageTableName,
+        IndexName: "byPeriod",
+        KeyConditionExpression: "#usageMonth = :usageMonth",
+        ExpressionAttributeNames: { "#usageMonth": "usageMonth" },
+        ExpressionAttributeValues: marshall({ ":usageMonth": "2026-08" }),
+      }),
+    );
+
+    expect(Items).toHaveLength(1);
+  });
+
+  it("reports the failed item rather than the whole batch", async () => {
+    const result = await handler(
+      event(
+        streamRecord("INSERT", { sk: JOB_ID }, "1"),
+        streamRecord("INSERT", transcriptionRecord(), "2"),
+      ),
+    );
+
+    expect(result.batchItemFailures).toEqual([]);
+    expect(await getUsageRecord()).toEqual(
+      expect.objectContaining({ jobId: JOB_ID }),
+    );
+  });
+
+  it("skips a record with no image", async () => {
+    const result = await handler(
+      event({ eventID: "e", eventName: "INSERT", dynamodb: {} }),
+    );
+
+    expect(result.batchItemFailures).toEqual([]);
+  });
+});

--- a/api/test/service/usageService.test.ts
+++ b/api/test/service/usageService.test.ts
@@ -1,0 +1,152 @@
+import type { Transcription } from "model";
+import { TranscriptionJobStatus } from "model";
+
+import { toUsageRecord } from "../../src/service/usageService";
+
+const IDENTITY_ID = "76c65a59-1c57-489b-be96-020ceaa9675a";
+const JOB_ID = "2e9b38b5-1df0-4841-8308-f174fb88aac7";
+
+const transcription = (overrides: Partial<Transcription> = {}) =>
+  ({
+    pk: IDENTITY_ID,
+    sk: JOB_ID,
+    date: "2026-08-06T01:02:03.000Z",
+    metadata: {
+      filename: "Confidential%20interview.wav",
+      filetype: "userUploadedFile",
+      mimetype: "audio/wav",
+      languages: "en-AU,fr-FR",
+      enablepiiredaction: "false",
+      generatesummary: "true",
+      targetlanguage: "es",
+      rpid: "RPID-1234",
+    },
+    uploadEvent: { object: { key: "users/x/y.upload", size: 1292288 } },
+    ...overrides,
+  }) as unknown as Transcription;
+
+describe("usageService", () => {
+  it("maps the metered units and dimensions of a job", () => {
+    const record = toUsageRecord(
+      transcription({
+        rpidPayload: { encodedId: "RPID-1234", organisation: "Faculty of X" },
+        audioSeconds: 128.4,
+        summaryUsage: { inputTokens: 900, outputTokens: 120 },
+        translationCharacters: 4321,
+      }),
+    );
+
+    expect(record).toEqual(
+      expect.objectContaining({
+        pk: `USER#${IDENTITY_ID}`,
+        sk: `JOB#${JOB_ID}`,
+        identityId: IDENTITY_ID,
+        jobId: JOB_ID,
+        rpid: "RPID-1234",
+        rpidPayload: { encodedId: "RPID-1234", organisation: "Faculty of X" },
+        sourceLanguages: ["en-AU", "fr-FR"],
+        targetLanguage: "es",
+        mimeType: "audio/wav",
+        piiRedaction: false,
+        summaryRequested: true,
+        translationRequested: true,
+        bytesUploaded: 1292288,
+        audioSeconds: 128.4,
+        summaryInputTokens: 900,
+        summaryOutputTokens: 120,
+        translationCharacters: 4321,
+        usageMonth: "2026-08",
+        startedAt: "2026-08-06T01:02:03.000Z",
+        updatedAt: "2026-08-06T01:02:03.000Z",
+      }),
+    );
+  });
+
+  it("retains no content, filename, or storage keys", () => {
+    const record = toUsageRecord(
+      transcription({
+        downloadKey: `users/${IDENTITY_ID}/${JOB_ID}.json`,
+        summaryKey: `users/${IDENTITY_ID}/summary/${JOB_ID}`,
+        translationKey: `users/${IDENTITY_ID}/translations/${JOB_ID}/es`,
+      }),
+    );
+
+    const serialised = JSON.stringify(record);
+    expect(serialised).not.toContain("Confidential");
+    expect(serialised).not.toContain("filename");
+    expect(serialised).not.toContain("downloadKey");
+    expect(serialised).not.toContain("summaryKey");
+    expect(serialised).not.toContain("translationKey");
+    expect(serialised).not.toContain("users/");
+  });
+
+  it("records the language Transcribe resolved for a multi-language job", () => {
+    const record = toUsageRecord(
+      transcription({
+        transcriptionResponse: {
+          TranscriptionJob: {
+            TranscriptionJobStatus: TranscriptionJobStatus.IN_PROGRESS,
+            LanguageCodes: [{ LanguageCode: "fr-FR" }],
+            LanguageOptions: ["en-AU", "fr-FR"],
+          },
+        },
+      }),
+    );
+
+    expect(record.resolvedLanguage).toEqual("fr-FR");
+    expect(record.status).toEqual(TranscriptionJobStatus.IN_PROGRESS);
+    expect(record.completedAt).toBeUndefined();
+  });
+
+  it("stamps completedAt and the failure reason for a terminal job", () => {
+    const record = toUsageRecord(
+      transcription({
+        jobStatusUpdated: {
+          detail: {
+            TranscriptionJobStatus: "FAILED",
+            FailureReason: "The Research Project ID (RPID) is required.",
+          },
+        },
+      }),
+    );
+
+    expect(record.status).toEqual("FAILED");
+    expect(record.failureReason).toEqual(
+      "The Research Project ID (RPID) is required.",
+    );
+    expect(record.completedAt).toEqual("2026-08-06T01:02:03.000Z");
+  });
+
+  it("treats a job with no target language as untranslated", () => {
+    const record = toUsageRecord(
+      transcription({
+        metadata: {
+          ...transcription().metadata,
+          targetlanguage: "",
+          generatesummary: "false",
+        },
+      }),
+    );
+
+    expect(record.translationRequested).toBe(false);
+    expect(record.targetLanguage).toBeUndefined();
+    expect(record.summaryRequested).toBe(false);
+  });
+
+  it("carries the translation status and failure message", () => {
+    const record = toUsageRecord(
+      transcription({
+        translationJob: {
+          jobId: "tjid",
+          status: "FAILED",
+          message: "UnsupportedLanguagePairException",
+        },
+      }),
+    );
+
+    expect(record.translationStatus).toEqual("FAILED");
+    expect(record.translationFailureReason).toEqual(
+      "UnsupportedLanguagePairException",
+    );
+  });
+});

--- a/api/test/util/transcript.test.ts
+++ b/api/test/util/transcript.test.ts
@@ -1,0 +1,70 @@
+import {
+  transcriptDurationSeconds,
+  translationCharacterCount,
+} from "../../src/util/transcript";
+
+describe("transcript", () => {
+  it("measures duration from the last thing Transcribe heard", () => {
+    expect(
+      transcriptDurationSeconds({
+        results: {
+          segments: [
+            {
+              start_time: "0.0",
+              end_time: "2.0",
+              alternatives: [{ transcript: "Hello world." }],
+            },
+            {
+              start_time: "2.0",
+              end_time: "612.5",
+              alternatives: [{ transcript: "How are you?" }],
+            },
+          ],
+        },
+      }),
+    ).toEqual(612.5);
+  });
+
+  it("falls back to word-level items when there are no segments", () => {
+    expect(
+      transcriptDurationSeconds({
+        results: {
+          items: [
+            { start_time: "0.0", end_time: "1.5" },
+            { start_time: "1.5", end_time: "3.25" },
+            { type: "punctuation" },
+          ],
+        },
+      }),
+    ).toEqual(3.25);
+  });
+
+  it("returns undefined for a transcript with no timings", () => {
+    expect(
+      transcriptDurationSeconds({
+        results: { transcripts: [{ transcript: "Hello world." }] },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("counts billable translation characters", () => {
+    expect(
+      translationCharacterCount({
+        results: {
+          segments: [
+            {
+              start_time: "0.0",
+              end_time: "2.0",
+              alternatives: [{ transcript: "Hello world." }],
+            },
+            {
+              start_time: "2.0",
+              end_time: "4.0",
+              alternatives: [{ transcript: "How are you?" }],
+            },
+          ],
+        },
+      }),
+    ).toEqual(24);
+  });
+});

--- a/deployment/lib/api-stack.ts
+++ b/deployment/lib/api-stack.ts
@@ -9,12 +9,14 @@ import * as events from "aws-cdk-lib/aws-events";
 import * as targets from "aws-cdk-lib/aws-events-targets";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as eventsources from "aws-cdk-lib/aws-lambda-event-sources";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import * as route53 from "aws-cdk-lib/aws-route53";
 import * as route53targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { HttpMethods } from "aws-cdk-lib/aws-s3";
 import * as s3n from "aws-cdk-lib/aws-s3-notifications";
+import * as sqs from "aws-cdk-lib/aws-sqs";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 
@@ -73,6 +75,33 @@ export class ApiStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
     (dataTable.node.defaultChild! as ddb.CfnTable).overrideLogicalId("Table");
+
+    const usageTable = new ddb.Table(this, "UsageTable", {
+      partitionKey: {
+        name: "pk",
+        type: ddb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: "sk",
+        type: ddb.AttributeType.STRING,
+      },
+      billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
+      deletionProtection: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+    usageTable.addGlobalSecondaryIndex({
+      indexName: "byRpid",
+      partitionKey: { name: "rpid", type: ddb.AttributeType.STRING },
+      sortKey: { name: "startedAt", type: ddb.AttributeType.STRING },
+    });
+    usageTable.addGlobalSecondaryIndex({
+      indexName: "byPeriod",
+      partitionKey: { name: "usageMonth", type: ddb.AttributeType.STRING },
+      sortKey: { name: "startedAt", type: ddb.AttributeType.STRING },
+    });
 
     const dataBucket = new s3.Bucket(this, "TranscriptionBucket", {
       bucketName:
@@ -305,8 +334,8 @@ export class ApiStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_24_X,
       description:
         "Copies transcription job output to the user's readable folder",
-      timeout: cdk.Duration.seconds(15),
-      memorySize: 1024,
+      timeout: cdk.Duration.seconds(60),
+      memorySize: 2048,
       entry: "../api/src/event/copyOutputHandler.ts",
       handler: "handler",
       bundling: {
@@ -580,6 +609,47 @@ export class ApiStack extends cdk.Stack {
         sourceArn: translateJobStateChangeRule.ruleArn,
       },
     );
+
+    const usageProjectionFunction = new NodejsFunction(
+      this,
+      "UsageProjectionFunction",
+      {
+        runtime: lambda.Runtime.NODEJS_24_X,
+        description:
+          "Projects transcription records into the permanent usage table",
+        timeout: cdk.Duration.seconds(30),
+        memorySize: 512,
+        entry: "../api/src/event/usageProjectionHandler.ts",
+        handler: "handler",
+        bundling: {
+          minify: true,
+          sourceMap: true,
+          target: "es2020",
+        },
+        environment: {
+          USAGE_TABLE_NAME: usageTable.tableName,
+          APPLICATION_NAME: props.parameters.ApplicationName,
+          ENVIRONMENT: props.parameters.Environment,
+        },
+      },
+    );
+    const usageProjectionDlq = new sqs.Queue(this, "UsageProjectionDlq", {
+      retentionPeriod: cdk.Duration.days(14),
+      enforceSSL: true,
+    });
+
+    usageProjectionFunction.addEventSource(
+      new eventsources.DynamoEventSource(dataTable, {
+        startingPosition: lambda.StartingPosition.LATEST,
+        batchSize: 100,
+        maxBatchingWindow: cdk.Duration.seconds(10),
+        retryAttempts: 3,
+        bisectBatchOnError: true,
+        reportBatchItemFailures: true,
+        onFailure: new eventsources.SqsDlq(usageProjectionDlq),
+      }),
+    );
+    usageTable.grantWriteData(usageProjectionFunction);
 
     const userPoolClient = userPool.addClient("UserPoolClient", {
       supportedIdentityProviders:

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -248,6 +248,42 @@ const Login: NextPageWithLayout = () => {
             </Box>
             <Box>
               <Heading as={"h3"} fontSize={"md"} pb={1}>
+                Usage information
+              </Heading>
+              <Text>
+                So we can report on how the service is used and what it costs,
+                we keep a record of each transcription after the media and
+                transcript themselves have been deleted. This record is kept
+                indefinitely and covers:
+              </Text>
+              <List.Root listStylePosition={"inside"}>
+                <List.Item>
+                  The research project (RPID) the transcription was assigned to,
+                  and its faculty and supervisor
+                </List.Item>
+                <List.Item>
+                  Who submitted it, and when it started and finished
+                </List.Item>
+                <List.Item>
+                  The languages, media format, and options chosen, such as PII
+                  redaction, summaries, and translation
+                </List.Item>
+                <List.Item>
+                  How much was processed: minutes of audio, bytes uploaded,
+                  summary tokens, and translated characters
+                </List.Item>
+                <List.Item>
+                  Whether the transcription succeeded, and why it failed if it
+                  did not
+                </List.Item>
+              </List.Root>
+              <Text mt={2}>
+                It never includes your media, transcripts, translations,
+                summaries, or file names.
+              </Text>
+            </Box>
+            <Box>
+              <Heading as={"h3"} fontSize={"md"} pb={1}>
                 PII redaction
               </Heading>
               <Text>

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./rpid";
 export * from "./transcribeQuotaProps";
 export * from "./transcription";
+export * from "./usage";

--- a/model/src/transcription.ts
+++ b/model/src/transcription.ts
@@ -14,6 +14,7 @@ export interface Transcription {
   metadata: {
     filetype: string;
     languagecode: string;
+    languages?: string;
     mimetype: string;
     filename: string;
     generatesummary: string;
@@ -22,9 +23,16 @@ export interface Transcription {
     rpid?: string;
   };
   date: string;
+  rpidPayload?: Record<string, unknown>;
   downloadKey?: string;
   summaryKey?: string;
   translationKey?: string;
+  audioSeconds?: number;
+  summaryUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+  };
+  translationCharacters?: number;
   translationJob?: {
     jobId: string;
     status: string;

--- a/model/src/usage.ts
+++ b/model/src/usage.ts
@@ -1,0 +1,47 @@
+import type { TranscriptionJobStatus } from "./transcription";
+
+export interface UsageRecord {
+  /** `USER#{identityId}` */
+  pk: string;
+  /** `JOB#{jobId}` */
+  sk: string;
+  identityId: string;
+  jobId: string;
+
+  rpid?: string;
+  rpidPayload?: Record<string, unknown>;
+
+  sourceLanguages?: string[];
+  resolvedLanguage?: string;
+  targetLanguage?: string;
+  mimeType?: string;
+
+  piiRedaction: boolean;
+  summaryRequested: boolean;
+  translationRequested: boolean;
+
+  bytesUploaded?: number;
+  audioSeconds?: number;
+  summaryInputTokens?: number;
+  summaryOutputTokens?: number;
+  translationCharacters?: number;
+
+  status?: TranscriptionJobStatus;
+  failureReason?: string;
+  translationStatus?: string;
+  translationFailureReason?: string;
+
+  usageMonth: string;
+  startedAt: string;
+  updatedAt: string;
+  completedAt?: string;
+  expiredAt?: string;
+}
+
+export const USAGE_PK_PREFIX = "USER#";
+export const USAGE_SK_PREFIX = "JOB#";
+
+export const usagePartitionKey = (identityId: string) =>
+  `${USAGE_PK_PREFIX}${identityId}`;
+
+export const usageSortKey = (jobId: string) => `${USAGE_SK_PREFIX}${jobId}`;


### PR DESCRIPTION
[AI generated]

## Summary

- add a permanent usage table, with no TTL, so job metadata outlives the 14-day deletion of the media and transcript
- project records into it from the transcription table's DynamoDB stream, which until now had no consumer
- meter audio duration, Bedrock summary tokens and translated characters, none of which were previously recorded
- keep the RPID and the DMP lookup response against each job for research project attribution
- disclose on the landing page what the audit log retains (ERP-4966)

## Notes

The projection is an allowlist. Filenames, storage keys, transcripts, summaries and translations are never copied into a table that is never deleted, and a test asserts this by serialising the record and checking those values are absent.

Stream images are snapshots rather than deltas, so each write is a complete, idempotent projection and one row per job converges regardless of redelivery or replay. A condition on `updatedAt` stops a redelivered older batch regressing a finished job, and `startedAt`, `usageMonth` and `completedAt` are written once so reporting periods stay stable.

The event source starts at `LATEST`. A job already in flight still gets a full usage record on its next state change, so only jobs that finish before this is first deployed are missed. Batches that exhaust their retries go to a dead-letter queue rather than disappearing.

Two GSIs support the expected reporting: `byRpid` for research project and faculty attribution, and `byPeriod` for whole-of-service usage in a month without scanning.

Amazon Transcribe reports no audio duration on its API or its EventBridge event, so duration is derived from the largest `end_time` in the transcript. `copyOutputHandler` now parses the full output to do this, so its timeout and memory have been raised.

The DMP `getRpid` response is stored as an untyped blob. It does not currently expose Field of Research or HDR status, so those dimensions in the ticket need the DMP to join on the RPID.
